### PR TITLE
feat: include shared build, update server config, and add Supabase migration

### DIFF
--- a/server/DEPLOY.md
+++ b/server/DEPLOY.md
@@ -1,0 +1,48 @@
+# Deployment Guide
+
+This document outlines how to deploy the OutdoorTeam backend to Render and prepare the application for production.  The backend is located in the `server/` directory and depends on a shared set of TypeScript schemas in the top‑level `shared/` directory.  The steps below ensure that the shared code is compiled into the server build output and that the service runs reliably in a production environment.
+
+## Render configuration
+
+When creating a new **Web Service** in Render, use the following settings:
+
+| Setting        | Value                                           | Notes |
+|---------------|--------------------------------------------------|------|
+| Root Directory | `server/`                                       | Keep this as‑is so Render runs commands from the server folder. |
+| Build Command | `npm ci --include=dev && npm run build`          | The `--include=dev` flag installs dev dependencies such as TypeScript and type definitions.  Running `npm run build` compiles both `server/` and `shared/` into `server/dist`. |
+| Start Command | `npm start`                                      | This runs `node dist/server/index.js` as defined in `package.json`. |
+| Node version   | 20.x                                            | Specified via `"engines": { "node": "20.x" }` in `package.json` for stability. |
+
+During the first build, Render will install dependencies, compile the TypeScript code, and then start your server from the compiled output.  If the build fails, check the logs and ensure that TypeScript errors are fixed rather than suppressed.
+
+## Environment variables
+
+Configure the following environment variables in Render.  Never commit secrets to the repository:
+
+- **SUPABASE_URL** – Base URL of your Supabase project.
+- **SUPABASE_ANON_KEY** – Public anon key for client‑side interactions.  Used by the front‑end and mobile app.
+- **SUPABASE_SERVICE_ROLE_KEY** – Service role key used by the backend for privileged operations (e.g. inserting into tables with RLS policies).  Do **not** expose this in the front‑end.
+- **JWT_SECRET** – Secret string used to sign JSON Web Tokens.  Must be the same on all server instances.
+- **VAPID_PUBLIC_KEY** and **VAPID_PRIVATE_KEY** – Keys used for Web Push notifications.  Generate a proper key pair and set both values.
+- Any other variables referenced in the codebase (e.g. `DATA_DIRECTORY` for uploaded files).
+
+## Supabase configuration
+
+To allow authentication and API requests from your production domain, adjust your Supabase project settings:
+
+1. **Site URL and Redirect URLs** – In the Supabase Dashboard under *Authentication → Settings*, set the **Site URL** to your public domain (e.g. `https://app.mioutdoorteam.com`) and include the same URL in **Redirect URLs**.  This ensures that OAuth and magic‑link flows return to your site.
+2. **CORS** – Under *Authentication → Settings*, add your frontend domain and backend domain to the list of allowed origins so that browsers can call your Supabase endpoints without being blocked.
+3. **Database migrations** – Apply the migration script `supabase_migration_outdoorteam.sql` (provided in this repository) using the SQL editor in Supabase or via the CLI.  This script adds the new tables (`content_library`, `broadcast_messages`, `user_plan_assignments`) and the `is_active` column to `public.users`, and sets up row‑level security (RLS) policies.  The script is idempotent and safe to run multiple times.
+4. **RLS policies** – Review your existing policies.  The migration script enables RLS on the new tables and defines read policies.  Do not change policies on existing tables unless you know what you are doing.
+
+## Post‑deployment checklist
+
+Use this checklist after deploying to ensure everything works correctly:
+
+- [ ] Hit `GET /health` or `/healthz` on your deployed service and verify it returns a 200 response with status `ok`.
+- [ ] Inspect Render logs to confirm there are **no** `MODULE_NOT_FOUND` errors related to `validation‑schemas.js`.  If such an error appears, confirm that the shared code compiled into `server/dist/shared`.
+- [ ] From your mobile app or frontend, perform a login and a few API calls (e.g. updating daily habits) to ensure JWT authentication and database writes work with the remote backend.
+- [ ] In Supabase, confirm the new tables `content_library`, `broadcast_messages`, and `user_plan_assignments` exist.  Check that the `users` table now has the `is_active` column.  Verify that RLS policies on these tables behave as expected: anyone can read from `content_library` and `broadcast_messages`, and each user can only read their own rows in `user_plan_assignments`.
+- [ ] If you added or modified environment variables, verify that they are correctly set in the Render environment.
+
+Once all these checks pass, your backend should be ready for production use and your APK can communicate with the deployed API.

--- a/server/package.json
+++ b/server/package.json
@@ -3,11 +3,12 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18"
-  },
+   "node": "20.x"
+      },
+
   "scripts": {
-    "build": "tsc -p . || true",
-    "start": "node dist/index.js",
+    "buildtsc -p .",
+    "start": "node dist/server/index.js
     "dev": "tsx watch index.ts"
   },
   "dependencies": {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,17 +1,16 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ES2020",
+    "module": "ES2022",
     "moduleResolution": "Bundler",
     "outDir": "dist",
-    "rootDir": ".",
+    "rootDir": "..",
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "types": ["node"],
-    "noImplicitAny": false,
-    "noEmitOnError": false   // <-- AGREGADA
+    "noEmitOnError": true
   },
-  "include": ["**/*.ts", "types/**/*.d.ts"],
-  "exclude": ["dist", "node_modules"]
+  "include": ["server/**/*.ts", "shared/**/*.ts"],
+  "exclude": ["dist", "node_modules", "client", "android", "scripts"]
 }

--- a/shared/validation-schemas.ts
+++ b/shared/validation-schemas.ts
@@ -75,7 +75,7 @@ export const broadcastMessageSchema = z.object({
 
 // Plan assignment schema
 export const planAssignmentSchema = z.object({
-  planId: z.number().positive()
+  pla nId:z.string().uuid()
 });
 
 // Toggle user status schema

--- a/supabase_migration_outdoorteam.sql
+++ b/supabase_migration_outdoorteam.sql
@@ -1,0 +1,102 @@
+-- supabase_migration_outdoorteam.sql
+--
+-- This migration script adds new tables and columns required by the
+-- OutdoorTeam backend and defines row‑level security (RLS) policies.
+-- It is idempotent: running it multiple times will not cause errors or
+-- duplicate objects because each operation checks for existence before
+-- creating anything.
+
+-- 1) Add `is_active` column to public.users (if not already present)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'users'
+      AND column_name  = 'is_active'
+  ) THEN
+    ALTER TABLE public.users
+      ADD COLUMN is_active boolean DEFAULT true;
+  END IF;
+END $$;
+
+-- 2) Create table public.content_library
+CREATE TABLE IF NOT EXISTS public.content_library (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  description text,
+  video_url text,
+  category text NOT NULL CHECK (category IN ('exercise','active_breaks','meditation')),
+  subcategory text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid REFERENCES auth.users(id)
+);
+
+-- Enable RLS and add a read policy for content_library
+ALTER TABLE public.content_library ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='content_library' AND policyname='content_library_read_all'
+  ) THEN
+    CREATE POLICY content_library_read_all
+      ON public.content_library FOR SELECT
+      USING (true);
+  END IF;
+END $$;
+
+-- 3) Create table public.broadcast_messages
+CREATE TABLE IF NOT EXISTS public.broadcast_messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  body text NOT NULL,
+  url text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid REFERENCES auth.users(id)
+);
+
+-- Enable RLS and add a read policy for broadcast_messages
+ALTER TABLE public.broadcast_messages ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='broadcast_messages' AND policyname='broadcast_messages_read_all'
+  ) THEN
+    CREATE POLICY broadcast_messages_read_all
+      ON public.broadcast_messages FOR SELECT
+      USING (true);
+  END IF;
+END $$;
+
+-- 4) Create table public.user_plan_assignments (many‑to‑many relation)
+CREATE TABLE IF NOT EXISTS public.user_plan_assignments (
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  plan_id uuid NOT NULL REFERENCES public.training_plans(id) ON DELETE CASCADE,
+  assigned_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, plan_id)
+);
+
+-- Index to speed up lookups by user_id
+CREATE INDEX IF NOT EXISTS idx_user_plan_assignments_user
+  ON public.user_plan_assignments(user_id);
+
+-- Enable RLS and restrict reads to the owning user
+ALTER TABLE public.user_plan_assignments ENABLE ROW LEVEL SECURITY;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='user_plan_assignments' AND policyname='upa_select_own'
+  ) THEN
+    CREATE POLICY upa_select_own
+      ON public.user_plan_assignments FOR SELECT
+      USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+-- Note: No insert/update/delete policies are defined for the new tables.
+-- These operations should be performed by the backend using the service role key.


### PR DESCRIPTION
This pull request integrates the shared TypeScript code into the server build output, updates the server build/start scripts and Node version, fixes the planId type, adds deployment documentation, and provides an idempotent Supabase migration script.

**Key changes**
- **server/tsconfig.json**: configure TypeScript to compile both `server` and `shared` directories into `server/dist` using `rootDir` set to `..`.
- **server/package.json**: remove `|| true` from the build script, adjust the start script to run `dist/server/index.js`, and pin the Node engine to `20.x`.
- **shared/validation-schemas.ts**: change `planId` in `planAssignmentSchema` from `number` to `string().uuid()` to align with the `uuid` type in the database.
- **server/DEPLOY.md**: add a deployment guide for Render, including commands, environment variables, and post-deployment checklist.
- **supabase_migration_outdoorteam.sql**: add a migration script that:
  - Adds an `is_active` column to `public.users` if it doesn't exist.
  - Creates `content_library`, `broadcast_messages`, and `user_plan_assignments` tables with appropriate columns and constraints.
  - Enables row-level security and defines simple SELECT policies.
  - Creates an index on `user_plan_assignments.user_id`.

These changes ensure that the backend starts correctly on Render, the front-end and APK can communicate with it, and the database schema matches the Zod validations.